### PR TITLE
`getrandevents` works with unnested directories, as well as arbitrary channel order

### DIFF
--- a/pytesdaq/io/hdf5.py
+++ b/pytesdaq/io/hdf5.py
@@ -1571,7 +1571,7 @@ def getrandevents(basepath, evtnums, seriesnums, cut=None, channels=None,
 
     h5_reader = H5Reader()
 
-    first_file = sorted(glob(f'{basepath}/*/*.hdf5'))[0]
+    first_file = sorted(glob(f'{basepath}/**/*.hdf5', recursive=True))[0]
 
     if channels is None:
         connection_dict = h5_reader.get_connection_dict(


### PR DESCRIPTION
This PR fixes two issues with `getrandevents`:

1. The function will now work with unnested directories
2. The function updates the channel order from `H5Reader.read_many_events` such that it matches what's expected from the input.

For 2, this is related to issue #17, but is more of a hotfix, as that issue still remains for `H5Reader.read_many_events`.