### PR TITLE
Feature/offsets dict

### DIFF
--- a/pytesdaq/processing/_iv_didv_tools.py
+++ b/pytesdaq/processing/_iv_didv_tools.py
@@ -237,6 +237,15 @@ def _sc_noise(freqs, tload, squiddc, squidpole, squidn, rload, inductance):
     s_isquid = (squiddc * (1.0 + (squidpole / freqs)**squidn))**2.0
     return s_iloadsc + s_isquid
 
+def _get_current_offset_metadata(metadata, channel_name):
+    """
+    Helper function to get the current offset set by the slider on
+    the FEB controller labview script.
+    """
+    voltage_offset = metadata[0]['detector_config'][channel_name]['output_offset']
+    close_loop_norm = metadata[0]['detector_config'][channel_name]['close_loop_norm']
+    return voltage_offset/close_loop_norm
+
 class IVanalysis(object):
     """
     Class to aid in the analysis of an IV/dIdV sweep as processed by
@@ -1801,3 +1810,48 @@ class IVanalysis(object):
             ylims_current=ylims_current,
             ylims_power=ylims_power,
         )
+
+
+    def get_offsets_dict(self, metadata, channel_name, lgcdiagnostics=False):
+        """
+        Function to get a dictionary of offsets of i0 and ibias used by
+        QETpy to calculate the i0, r0, p0, etc. of a given dIdV.
+
+        Parameters
+        ----------
+        metadata : array
+            Generated when loading traces. Can just be one element long.
+            Used to find the current offset set by the slider on the FEB
+            control labview script.
+
+        channel_name: str
+            Used to get the right channel out of the metadata
+
+        Returns
+        -------
+        offsets_dict: dict
+            A dictionary containing the various offsets used by QETpy
+            to calculate the biasparams dict, the dIdP, etc.
+
+        """
+        
+        output_offset_during_didv = _get_current_offset_metadata(metadata, channel_name)
+
+        IV_i0_offset = self.ivobj.ioff[0][1]
+        IV_i0_offset_err = self.ivobj.ioff_err[0][1]
+        IV_ibias_offset = self.ivobj.ibias_off[0][1]
+        IV_ibias_offset_err = self.ivobj.ibias_off_err[0][1]
+        
+        rp_measured = self.df['rp'][0]
+        
+        return_dict = {
+            "i0_off": IV_i0_offset,
+            "i0_off_err": IV_i0_offset_err,
+            "ibias_off": IV_ibias_offset,
+            "ibias_off_err": IV_ibias_offset_err,
+            "i0_changable_offset": output_offset_during_didv,
+            "rp": rp_measured,
+            "IVobj": self,
+        }
+
+        return return_dict


### PR DESCRIPTION
Added a feature that gives you a offsets_dict after a IV sweep has been calculated. This offsets_dict is used by QETpy during dIdV processing to measure rather than set the r0, and calculate smallsignalparams and dIdP etc. 