### PR TITLE
now can have None as a calibration dict without getting code to fail

### DIFF
--- a/pytesdaq/processing/_iv_didv_tools.py
+++ b/pytesdaq/processing/_iv_didv_tools.py
@@ -1911,9 +1911,12 @@ class IVanalysis(object):
 
         """
         
-        output_offset_during_iv_cal = _get_current_offset_metadata(metadata, channel_name, 
-                                                                 lgc_calibrated_offsets=True, 
-                                                                 calibration_dict=calibration_dict)
+        if calibration_dict is not None:
+            output_offset_during_iv_cal = _get_current_offset_metadata(metadata, channel_name, 
+                                                                      lgc_calibrated_offsets=True, 
+                                                                      calibration_dict=calibration_dict)
+        else:
+            output_offset_during_iv_cal = None
         output_offset_during_iv_uncal = _get_current_offset_metadata(metadata, channel_name, 
                                                                  lgc_calibrated_offsets=False, 
                                                                  calibration_dict=calibration_dict)


### PR DESCRIPTION
When generating an offset_dict from IV/dIdV sweeps, you now don't have to use a calibration_dict when generating the offset_dict if you don't want to.