### PR TITLE
Add GitLab CI configuration for repository mirroring

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,22 @@
+stages:
+  - mirror
+
+mirror_from_github:
+  stage: mirror
+  image: alpine:latest
+  variables:
+    GIT_STRATEGY: none
+  before_script:
+    - apk add --no-cache git ca-certificates
+    - git config --global user.email "mirror-bot@gitlab"
+    - git config --global user.name "GitLab Mirror Bot"
+  script:
+    # Clone GitHub as a bare mirror
+    - git clone --mirror https://${GITHUB_USER}:${GITHUB_PAT}@github.com/spice-herald/pytesdaq.git repo.git
+    - cd repo.git
+
+    # Push everything to GitLab (force to keep mirror clean)
+    - git push --mirror https://${GITLAB_USER}:${GITLAB_PAT}@gitlab.in2p3.fr/tesseract/daq/pytesdaq.git
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "push"'


### PR DESCRIPTION
Set up CI pipeline to mirror GitHub repository to GitLab.